### PR TITLE
電話網につながる製品の追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,6 +173,7 @@ Mantela を利用した各種アプリケーションが開発されています
 <li><a rel="external" href="https://network.yamaha.com/products/routers/rt57i/index">YAMAHA RT57i</a></li>
 <li><a rel="external" href="https://network.yamaha.com/products/routers/rt58i/index">YAMAHA RT58i</a></li>
 <li><a rel="external" href="https://network.yamaha.com/products/routers/nvr500/index">YAMAHA NVR500</a></li>
+<li><a rel="external" href="https://network.yamaha.com/products/routers/nvr510/index">YAMAHA NVR510</a></li>
 <li><a rel="external" href="https://www.icom.co.jp/support/manual/2386/">ICOM VE-TA10</a>（ただし、<a rel="external" href="https://zenn.dev/kusaremkn/articles/cb32b500fc1334">インチキ</a>が必要）</li>
 <li><a rel="external" href="https://network.yamaha.com/products/routers/rt56v/index">YAMAHA RT56v</a></li>
 <li><a rel="external" href="https://www.brother.co.jp/product/nwp/mip3020/index.aspx">Brother MIP-3020</a></li>
@@ -190,6 +191,7 @@ Mantela を利用した各種アプリケーションが開発されています
 <li><a rel="external" href="https://hmi-basen.dk/blobs/brugsvejl/15361.pdf">TelePhoSee WVP-2100 Series</a></li>
 <li><a rel="external" href="https://www.grandstream.com/products/ip-voice-telephony-gxp-series-ip-phones/gxp-series-basic-ip-phones/product/gxp1620/gxp1625">Grandstream GXP1625</a></li>
 <li><a rel="external" href="https://www.nyc.co.jp/products/voicecaster_ip_phone/index.html">株式会社ナカヨ IP-24N-ST101A</a></li>
+<li><a rel="external" href="https://support.hp.com/jp-ja/product/details/poly-vvx-accessories-series/model/2101765522">HP VVX250</a></li>
 </ul>
 </section>
 <section>


### PR DESCRIPTION
## 追加した機器
- [YAMAHA NVR510](https://network.yamaha.com/products/routers/nvr510/index)
- [VVX 250 | HP®](https://support.hp.com/jp-ja/product/details/poly-vvx-accessories-series/model/2101765522)
## 根拠
`Goryokaku` 局 (by halka) で安定して稼働しているため。