### PR TITLE
Web 電話アプリへのリンクを削除する

### DIFF
--- a/index.html
+++ b/index.html
@@ -186,7 +186,6 @@ Mantela を利用した各種アプリケーションが開発されています
 <h3>電話網に参加するにはどうしたらいいですか？</h3>
 <p>
 <a rel="external" href="https://zenn.dev/kusaremkn/articles/abd760f9f2f450">いまさら VoIP 網</a> などを参考に IP 電話サーバを設置する必要があります。
-単に電話したいだけなら <a rel="external" href="https://talk.108jiminy.jp/">Web 電話アプリ</a> を利用することもできます。
 </p>
 </section>
 <section>


### PR DESCRIPTION
Jiminy Public 局が提供している Web 電話アプリは長期間稼動しておらず、また局ごと廃止されると聞いております。そのため、Web 電話アプリへのリンクは削除したほうがよいでしょう。